### PR TITLE
Fix Kraken futures trade feed

### DIFF
--- a/src/worker/exchanges/kraken.ts
+++ b/src/worker/exchanges/kraken.ts
@@ -3,6 +3,7 @@ import Exchange from '../exchange'
 export default class extends Exchange {
   id = 'KRAKEN'
   private specs: { [pair: string]: number }
+  private isPFregex = /^PF_/ //
 
   protected endpoints = {
     PRODUCTS: [
@@ -122,14 +123,13 @@ export default class extends Exchange {
 
     if (json.feed === 'trade' && json.qty) {
       // futures
-
       return this.emitTrades(api.id, [
         {
           exchange: this.id,
           pair: json.product_id,
           timestamp: json.time,
           price: json.price,
-          size: json.product_id.startsWith('PF_') ? json.qty : json.qty / json.price,
+          size: this.isPFregex.test(json.product_id) ? json.qty : (json.qty / json.price),
           side: json.side
         }
       ])

--- a/src/worker/exchanges/kraken.ts
+++ b/src/worker/exchanges/kraken.ts
@@ -129,7 +129,7 @@ export default class extends Exchange {
           pair: json.product_id,
           timestamp: json.time,
           price: json.price,
-          size: json.qty / json.price,
+          size: json.qty,
           side: json.side
         }
       ])

--- a/src/worker/exchanges/kraken.ts
+++ b/src/worker/exchanges/kraken.ts
@@ -129,7 +129,7 @@ export default class extends Exchange {
           pair: json.product_id,
           timestamp: json.time,
           price: json.price,
-          size: json.qty,
+          size: json.product_id.startsWith('PF_') ? json.qty : json.qty / json.price,
           side: json.side
         }
       ])


### PR DESCRIPTION
For the pair PF_SOLUSD

1. Kraken Futures platform - pro.kraken.com
![image](https://github.com/Tucsky/aggr/assets/20586054/bb974b70-1888-48e7-a83a-916e08dab072)

2. https://charts.aggr.trade/zjqe

It's showing size in SOL instead of the size in USD
![image](https://github.com/Tucsky/aggr/assets/20586054/e5161883-d99d-4444-80c1-fe73c66dee97)

3. PR changes

Everything seems good now.
![image](https://github.com/Tucsky/aggr/assets/20586054/1cd75ae5-4f7f-49b3-9a4e-293cb2128f44)


We'll note another issue if we compare 1-2 is that trades are not showing up in the same order than on the kraken platform. 

Also noticed an issue where time isn't showing two digit minutes (if you choose to display actual time of trades instead of elapsed time since the trade occured). This will be filed separately 