### PR TITLE
Bug fix/pane time double digit minutes 

### DIFF
--- a/src/components/trades/tradesFeed.ts
+++ b/src/components/trades/tradesFeed.ts
@@ -265,9 +265,12 @@ export default class TradesFeed {
 
       if (!this.showTimeAgo) {
         const date = new Date(+trade.timestamp)
+        const minutes = date.getMinutes()
+
         timestampText = `${date.getHours()}:${
-          date.getMinutes() < 10 ? '0' : ''
-        }${date.getHours()}`
+          minutes < 10 ? '0' : ''
+        }${minutes}`
+
         timestampClass += ' -fixed'
       }
     }

--- a/src/components/trades/tradesFeed.ts
+++ b/src/components/trades/tradesFeed.ts
@@ -265,7 +265,9 @@ export default class TradesFeed {
 
       if (!this.showTimeAgo) {
         const date = new Date(+trade.timestamp)
-        timestampText = date.getHours() + ':' + date.getMinutes()
+        timestampText = `${date.getHours()}:${
+          date.getMinutes() < 10 ? '0' : ''
+        }${date.getHours()}`
         timestampClass += ' -fixed'
       }
     }


### PR DESCRIPTION
Hereby a fix for the minutes not always showing in double digits.
I also used template literals for it so the code is more readable

This fixes #349 