### PR TITLE
Add custom script options

### DIFF
--- a/src/components/SearchDialog.vue
+++ b/src/components/SearchDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <Dialog @clickOutside="hide" class="search-dialog" ref="dialog">
     <template v-slot:header>
-      <div v-if="paneId">
+      <div v-if="selectedPaneId">
         <div class="dialog__title">
           Connect
           <code class="-filled -green">
@@ -485,16 +485,26 @@ export default {
       return RESULTS_PER_PAGE
     },
     otherPanes() {
+      if (!this.selectedPaneId) {
+        return []
+      }
+
       return Object.keys(this.$store.state.panes.panes)
         .filter(a => a !== this.selectedPaneId)
         .map(a => this.$store.state.panes.panes[a])
     },
     paneName() {
-      if (this.selectedPaneId) {
-        return this.$store.getters['panes/getName'](this.selectedPaneId)
+      if (!this.selectedPaneId) {
+        return 'n/a'
       }
 
-      return ''
+      const name = this.$store.getters['panes/getName'](this.selectedPaneId)
+
+      if (!name.trim().length) {
+        return '👻'
+      }
+
+      return name
     },
     activeMarkets() {
       return Object.keys(this.$store.state.panes.marketsListeners)

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -27,8 +27,7 @@
         title="Maintain shift key to change timeframe on all panes"
         class="btn pane-chart__timeframe -text -cases"
         :class="[
-          timeframeForHuman === timeframeLabel &&
-            'pane-header__highlight'
+          timeframeForHuman === timeframeLabel && 'pane-header__highlight'
         ]"
       >
         <span>{{ timeframeLabel }}</span>

--- a/src/components/chart/IndicatorDialog.vue
+++ b/src/components/chart/IndicatorDialog.vue
@@ -160,7 +160,10 @@
           <i class="icon-cross"></i>
         </button>
       </div>
-      <div v-if="optionsQuery.length" class="indicator-search__results">
+      <div
+        v-if="optionsQuery.length"
+        class="indicator-options__list indicator-search__results"
+      >
         <indicator-option
           v-for="key in queryOptionsKeys"
           :key="key"
@@ -179,16 +182,18 @@
           title="Colors"
           id="indicator-right-colors"
         >
-          <indicator-option
-            v-for="key in colorOptionsKeys"
-            :key="key"
-            :name="key"
-            :pane-id="paneId"
-            :indicator-id="indicatorId"
-            :plot-types="plotTypes"
-            inline
-            @change="setIndicatorOption"
-          />
+          <div class="indicator-options__list">
+            <indicator-option
+              v-for="key in colorOptionsKeys"
+              :key="key"
+              :name="key"
+              :pane-id="paneId"
+              :indicator-id="indicatorId"
+              :plot-types="plotTypes"
+              inline
+              @change="setIndicatorOption"
+            />
+          </div>
         </ToggableSection>
 
         <ToggableSection
@@ -197,16 +202,18 @@
           title="Script"
           id="indicator-right-script"
         >
-          <indicator-option
-            v-for="key in scriptOptionsKeys"
-            :key="key"
-            :name="key"
-            :pane-id="paneId"
-            :indicator-id="indicatorId"
-            :plot-types="plotTypes"
-            ensure
-            @change="setIndicatorOption"
-          />
+          <div class="indicator-options__list">
+            <indicator-option
+              v-for="key in scriptOptionsKeys"
+              :key="key"
+              :name="key"
+              :pane-id="paneId"
+              :indicator-id="indicatorId"
+              :plot-types="plotTypes"
+              ensure
+              @change="setIndicatorOption"
+            />
+          </div>
         </ToggableSection>
 
         <ToggableSection
@@ -215,15 +222,17 @@
           title="Other"
           id="indicator-right-default"
         >
-          <indicator-option
-            v-for="key in defaultOptionsKeys"
-            :key="key"
-            :name="key"
-            :pane-id="paneId"
-            :indicator-id="indicatorId"
-            :plot-types="plotTypes"
-            @change="setIndicatorOption"
-          />
+          <div class="indicator-options__list">
+            <indicator-option
+              v-for="key in defaultOptionsKeys"
+              :key="key"
+              :name="key"
+              :pane-id="paneId"
+              :indicator-id="indicatorId"
+              :plot-types="plotTypes"
+              @change="setIndicatorOption"
+            />
+          </div>
         </ToggableSection>
 
         <ToggableSection title="Scale" id="indicator-right-scale">
@@ -327,6 +336,8 @@
 </template>
 
 <script lang="ts">
+/* eslint-disable vue/no-unused-components */
+
 import DialogMixin from '../../mixins/dialogMixin'
 import Tabs from '@/components/framework/Tabs.vue'
 import Tab from '@/components/framework/Tab.vue'
@@ -486,7 +497,7 @@ export default {
     }
   },
   created() {
-    this.restoreNavigationState()
+    this.restoreNavigation()
 
     this.$nextTick(() => {
       this.getPlotTypes()
@@ -496,11 +507,11 @@ export default {
     this.originalIndicator = JSON.parse(JSON.stringify(this.indicator))
   },
   beforeDestroy() {
-    this.saveNavigationState()
+    this.saveNavigation()
   },
   methods: {
-    restoreNavigationState() {
-      const navigationState = this.$store.state[this.paneId].navigationState
+    restoreNavigation() {
+      const navigationState = this.$store.state.app.indicatorDialogNavigation
 
       if (navigationState) {
         this.tab = navigationState.tab || 'options'
@@ -509,8 +520,8 @@ export default {
           navigationState.fontSizePx || (window.devicePixelRatio > 1 ? 12 : 14)
       }
     },
-    saveNavigationState() {
-      this.$store.commit(this.paneId + '/SET_NAVIGATION_STATE', {
+    saveNavigation() {
+      this.$store.commit('app/SET_INDICATOR_DIALOG_NAVIGATION', {
         tab: this.tab,
         optionsQuery: this.optionsQuery,
         fontSizePx: this.editorFontSize
@@ -534,13 +545,18 @@ export default {
       this.getOptionsKeys()
     },
     getScriptOptions(script) {
-      const keys = []
-      const reg = /options\.([a-zA-Z0-9_]+)/g
+      const keys = Object.keys(this.indicator.optionsDefinitions || {})
+      const reg =
+        /options\.([a-zA-Z0-9_]+)|[\s\n]*(\w[\d\w]+)[\s\n]*=[\s\n]*option\(/g
 
       let match
 
       do {
-        if ((match = reg.exec(script))) {
+        if (
+          (match = reg.exec(script)) &&
+          match[1] &&
+          keys.indexOf(match[1]) === -1
+        ) {
           keys.push(match[1])
         }
       } while (match)
@@ -697,22 +713,12 @@ export default {
         ...defaultOptionsKeys,
         ...defaultSeriesOptionsKeys,
         ...scriptOptionsKeys
-      ]
-        .filter((x, i, a) => {
-          if (ignoredOptionsKeys.indexOf(x) === -1 && a.indexOf(x) == i) {
-            return true
-          }
-          return false
-        })
-        .sort((a, b) => {
-          if (a > b) {
-            return 1
-          } else if (a < b) {
-            return -1
-          }
-
-          return 0
-        })
+      ].filter((x, i, a) => {
+        if (ignoredOptionsKeys.indexOf(x) === -1 && a.indexOf(x) == i) {
+          return true
+        }
+        return false
+      })
 
       const colorKeys = []
       const nonColorScriptKeys = []
@@ -999,6 +1005,12 @@ hr.-vertical {
         width: calc(25% - 0.75rem);
       }
     }
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
   }
 }
 

--- a/src/components/chart/IndicatorOption.vue
+++ b/src/components/chart/IndicatorOption.vue
@@ -1,76 +1,68 @@
 <template>
-  <div
-    class="indicator-option form-group"
-    :class="['-' + type, inline && 'indicator-option--inline']"
-  >
-    <label>
-      {{ label }}
-    </label>
-
-    <dropdown-button
-      v-if="name === 'lineType'"
-      v-model="value"
-      :options="{ 0: 'Simple', 1: 'with steps' }"
-      class="-outline form-control -arrow"
-      placeholder="lineType"
-      @input="setValue($event)"
-    ></dropdown-button>
-    <dropdown-button
-      v-else-if="/linestyle$/i.test(name)"
-      v-model="value"
-      :options="{
-        0: 'Solid',
-        1: 'Dotted',
-        2: 'Dashed',
-        3: 'LargeDashed',
-        4: 'SparseDotted'
-      }"
-      class="-outline form-control -arrow"
-      placeholder="lineStyle"
-      @input="setValue($event)"
-    ></dropdown-button>
-    <color-picker-control
-      v-else-if="type === 'color'"
+  <div class="indicator-option">
+    <component
+      v-if="type"
+      :is="componentName"
+      :pane-id="paneId"
+      :indicator-id="indicatorId"
       :label="label"
-      model="rgb"
-      allow-null
       :value="value"
+      :definition="definition"
       @input="setValue($event)"
-      @close="reloadIndicator"
-    ></color-picker-control>
-    <editable
-      v-else-if="type === 'string' || type === 'number'"
-      class="form-control"
-      :value="value"
-      @input="setValue($event)"
-    ></editable>
-    <label v-else-if="type === 'boolean'" class="checkbox-control">
-      <input
-        type="checkbox"
-        class="form-control"
-        :checked="value"
-        @change="setValue($event.target.checked)"
-      />
-      <span>{{ label }}</span>
-      <div></div>
-    </label>
+    >
+      <template v-if="definition.description" #description>
+        <i class="icon-info pl4" v-tippy :title="definition.description"></i>
+      </template>
+    </component>
   </div>
 </template>
 <script lang="ts">
 import { Component, Vue, Watch } from 'vue-property-decorator'
 import {
-  getDefaultIndicatorOptionValue,
-  getIndicatorOptionType
+  getIndicatorOptionType,
+  getDefaultIndicatorOptionValue
 } from './options'
-
-import DropdownButton from '@/components/framework/DropdownButton.vue'
-import ColorPickerControl from '../framework/picker/ColorPickerControl.vue'
+import { ALLOWED_OPTION_TYPES } from './serieBuilder'
 
 @Component({
-  name: 'IndicatorOption',
+  name: 'IndicatorOptions',
   components: {
-    DropdownButton,
-    ColorPickerControl
+    IndicatorOptionNumber: () =>
+      import(
+        /* webpackChunkName: "IndicatorOptionNumber"*/ '@/components/chart/options/IndicatorOptionNumber.vue'
+      ),
+    IndicatorOptionText: () =>
+      import(
+        /* webpackChunkName: "IndicatorOptionText"*/ '@/components/chart/options/IndicatorOptionText.vue'
+      ),
+    IndicatorOptionList: () =>
+      import(
+        /* webpackChunkName: "IndicatorOptionList"*/ '@/components/chart/options/IndicatorOptionList.vue'
+      ),
+    IndicatorOptionLineStyle: () =>
+      import(
+        /* webpackChunkName: "IndicatorOptionLineStyle"*/ '@/components/chart/options/IndicatorOptionLineStyle.vue'
+      ),
+    IndicatorOptionLineType: () =>
+      import(
+        /* webpackChunkName: "IndicatorOptionLineType"*/ '@/components/chart/options/IndicatorOptionLineType.vue'
+      ),
+    IndicatorOptionExchange: () =>
+      import(
+        /* webpackChunkName: "IndicatorOptionExchange"*/ '@/components/chart/options/IndicatorOptionExchange.vue'
+      ),
+    IndicatorOptionRange: () =>
+      import(
+        /* webpackChunkName: "IndicatorOptionRange"*/ '@/components/chart/options/IndicatorOptionRange.vue'
+      ),
+    IndicatorOptionCheckbox: () =>
+      import(
+        /* webpackChunkName: "IndicatorOptionCheckbox"*/ '@/components/chart/options/IndicatorOptionCheckbox.vue'
+      ),
+    IndicatorOptionColor: () =>
+      import(
+        /* webpackChunkName: "IndicatorOptionColor"*/ '@/components/chart/options/IndicatorOptionColor.vue'
+      )
   },
   props: {
     indicatorId: {
@@ -87,10 +79,6 @@ import ColorPickerControl from '../framework/picker/ColorPickerControl.vue'
     name: {
       type: String,
       required: true
-    },
-    inline: {
-      type: Boolean,
-      default: false
     },
     ensure: {
       type: Boolean,
@@ -114,8 +102,38 @@ export default class IndicatorOption extends Vue {
     ]
   }
 
+  get definition() {
+    return (
+      this.$store.state[this.paneId].indicators[this.indicatorId]
+        .optionsDefinitions[this.name] || {}
+    )
+  }
+
   get label() {
-    return this.name
+    return this.definition.label || this.name
+  }
+
+  get componentName() {
+    if (!this.type) {
+      return 'IndicatorOptionText'
+    }
+
+    if (this.name === 'lineType') {
+      return 'IndicatorOptionLineType'
+    }
+
+    if (this.name === 'lineStyle') {
+      return 'IndicatorOptionLineStyle'
+    }
+
+    return `IndicatorOption${this.type[0].toUpperCase()}${this.type
+      .toLowerCase()
+      .slice(1)}`
+  }
+
+  @Watch('definition')
+  onDefinitionChange() {
+    this.type = this.getType()
   }
 
   @Watch('currentIndicatorValue')
@@ -132,23 +150,49 @@ export default class IndicatorOption extends Vue {
 
   created() {
     this.value = this.getValue()
-    this.type = getIndicatorOptionType(
-      this.name,
-      this.plotTypes,
-      null,
-      this.currentIndicatorValue
-    )
+    this.type = this.getType()
 
-    if (this.ensure && typeof this.currentIndicatorValue === 'undefined') {
+    if (
+      this.ensure &&
+      typeof this.currentIndicatorValue === 'undefined' &&
+      this.value !== 'null'
+    ) {
       this.setValue(this.value)
     }
+  }
+
+  getType() {
+    const type =
+      this.definition.type ||
+      getIndicatorOptionType(
+        this.name,
+        this.plotTypes,
+        true,
+        this.currentIndicatorValue
+      )
+
+    if (!Object.values(ALLOWED_OPTION_TYPES).includes(type)) {
+      return 'number'
+    }
+
+    return type
   }
 
   getValue() {
     let preferedValue
 
-    if (typeof this.currentIndicatorValue !== 'undefined') {
+    if (
+      typeof this.currentIndicatorValue !== 'undefined' &&
+      this.currentIndicatorValue !== null
+    ) {
       preferedValue = this.currentIndicatorValue
+    }
+
+    if (
+      typeof preferedValue === 'undefined' &&
+      typeof this.definition.default !== 'undefined'
+    ) {
+      return this.definition.default
     }
 
     const defaultValue = getDefaultIndicatorOptionValue(
@@ -181,75 +225,17 @@ export default class IndicatorOption extends Vue {
     })
 
     this.value = value
-    this.type = getIndicatorOptionType(
-      this.name,
-      this.plotTypes,
-      true,
-      this.currentIndicatorValue
-    )
-  }
-
-  reloadIndicator() {
-    this.$store.commit(this.paneId + '/SET_INDICATOR_SCRIPT', {
-      id: this.indicatorId,
-      value: this.$store.state[this.paneId].indicators[this.indicatorId].script
-    })
+    this.type = this.getType()
   }
 }
 </script>
 <style lang="scss">
 .indicator-option {
-  &--inline > label {
-    margin: 0 0.5rem 0 0;
-  }
-
-  > label {
-    display: block;
-  }
-
-  &.-boolean,
-  &.-color {
-    display: flex;
-    align-items: center;
-
-    > label:first-child {
-      flex-grow: 1;
-      margin: 0;
-    }
-  }
-
-  &.-color > label {
-    flex-grow: 1;
-    color: var(--theme-color-base);
-    margin-right: 0.25rem;
-  }
-
-  &.-boolean {
-    > label:first-child {
-      display: none;
-    }
-
-    .checkbox-control {
-      flex-grow: 1;
-
-      > span {
-        flex-grow: 1;
-        word-break: break-word;
-      }
-    }
-  }
-
-  + .indicator-option {
-    margin-top: 1rem;
-  }
+  width: 100%;
+  max-width: 200px;
 
   .form-control {
-    width: 100%;
-    max-width: 200px;
-  }
-
-  .dropdown {
-    width: 100%;
+    min-width: 100px;
   }
 }
 </style>

--- a/src/components/chart/options.ts
+++ b/src/components/chart/options.ts
@@ -424,7 +424,7 @@ export function getIndicatorOptionType(
     value = getDefaultIndicatorOptionValue(key, plotTypes, forceCompute)
   }
 
-  let type = 'string'
+  let type = 'text'
 
   let typedValue
 
@@ -439,7 +439,7 @@ export function getIndicatorOptionType(
     typeof typedValue === 'boolean' ||
     /^(show|toggle|set|use)[A-Z]/.test(key)
   ) {
-    type = 'boolean'
+    type = 'checkbox'
   } else if (
     /color/i.test(key) ||
     /^rgba?/.test(typedValue) ||

--- a/src/components/chart/options/IndicatorOptionCheckbox.vue
+++ b/src/components/chart/options/IndicatorOptionCheckbox.vue
@@ -1,0 +1,35 @@
+<template>
+  <label class="indicator-option-checkbox checkbox-control">
+    <input
+      type="checkbox"
+      class="form-control"
+      :checked="value"
+      @change="$emit('input', $event.target.checked)"
+    />
+    <span>{{ label }}<slot name="description" /></span>
+    <div></div>
+  </label>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import IndicatorOptionMixin from '@/mixins/indicatorOptionMixin'
+
+@Component({
+  name: 'IndicatorOptionCheckbox',
+  mixins: [IndicatorOptionMixin]
+})
+export default class IndicatorOptionCheckbox extends Vue {}
+</script>
+<style lang="scss" scoped>
+.indicator-option-checkbox {
+  > span {
+    flex-grow: 1;
+    word-break: break-word;
+
+    > i {
+      line-height: 0.875;
+      vertical-align: bottom;
+    }
+  }
+}
+</style>

--- a/src/components/chart/options/IndicatorOptionColor.vue
+++ b/src/components/chart/options/IndicatorOptionColor.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="indicator-option-color">
+    <label>{{ label }}<slot name="description" /></label>
+    <color-picker-control
+      :label="label"
+      model="rgb"
+      allow-null
+      :value="value"
+      @input="$emit('input', $event)"
+      @close="reloadIndicator"
+    ></color-picker-control>
+  </div>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import IndicatorOptionMixin from '@/mixins/indicatorOptionMixin'
+import ColorPickerControl from '@/components/framework/picker/ColorPickerControl.vue'
+
+@Component({
+  name: 'IndicatorOptionColor',
+  mixins: [IndicatorOptionMixin],
+  components: {
+    ColorPickerControl
+  }
+})
+export default class IndicatorOptionColor extends Vue {
+  private value
+  private paneId
+  private indicatorId
+  private definition
+
+  mounted() {
+    console.log('color input', this.value, this.definition)
+  }
+
+  reloadIndicator() {
+    this.$store.commit(this.paneId + '/SET_INDICATOR_SCRIPT', {
+      id: this.indicatorId,
+      value: this.$store.state[this.paneId].indicators[this.indicatorId].script
+    })
+  }
+}
+</script>
+<style lang="scss" scoped>
+.indicator-option-color {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  > label > i {
+    vertical-align: bottom;
+    line-height: 1;
+  }
+}
+</style>

--- a/src/components/chart/options/IndicatorOptionExchange.vue
+++ b/src/components/chart/options/IndicatorOptionExchange.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="indicator-option-exchange form-group">
+    <label>{{ label }}<slot name="description" /></label>
+    <dropdown-button
+      v-model="value"
+      :options="exchanges"
+      :placeholder="definition.placeholder"
+      class="-outline form-control -arrow"
+      @input="$emit('input', $event)"
+    ></dropdown-button>
+  </div>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import IndicatorOptionMixin from '@/mixins/indicatorOptionMixin'
+import DropdownButton from '@/components/framework/DropdownButton.vue'
+
+@Component({
+  name: 'IndicatorOptionLineStyle',
+  mixins: [IndicatorOptionMixin],
+  components: {
+    DropdownButton
+  }
+})
+export default class IndicatorOptionLineStyle extends Vue {
+  get exchanges() {
+    return this.$store.getters['exchanges/getExchanges'].reduce(
+      (acc, exchange) => {
+        acc[exchange] = exchange
+        return acc
+      },
+      {
+        null: 'Choose'
+      }
+    )
+  }
+}
+</script>

--- a/src/components/chart/options/IndicatorOptionLineStyle.vue
+++ b/src/components/chart/options/IndicatorOptionLineStyle.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="indicator-option-line-style form-group">
+    <label>{{ label }}<slot name="description" /></label>
+    <dropdown-button
+      v-model="value"
+      :options="{
+        0: 'Solid',
+        1: 'Dotted',
+        2: 'Dashed',
+        3: 'LargeDashed',
+        4: 'SparseDotted'
+      }"
+      class="-outline form-control -arrow"
+      :placeholder="definition.placeholder || 'lineStyle'"
+      @input="$emit('input', $event)"
+    ></dropdown-button>
+  </div>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import IndicatorOptionMixin from '@/mixins/indicatorOptionMixin'
+import DropdownButton from '@/components/framework/DropdownButton.vue'
+
+@Component({
+  name: 'IndicatorOptionLineStyle',
+  mixins: [IndicatorOptionMixin],
+  components: {
+    DropdownButton
+  }
+})
+export default class IndicatorOptionLineStyle extends Vue {}
+</script>

--- a/src/components/chart/options/IndicatorOptionLineType.vue
+++ b/src/components/chart/options/IndicatorOptionLineType.vue
@@ -1,0 +1,26 @@
+<template>
+  <label class="indicator-option-line-type form-group">
+    <label>{{ label }}<slot name="description" /></label>
+    <dropdown-button
+      v-model="value"
+      :options="{ 0: 'Simple', 1: 'with steps' }"
+      class="-outline form-control -arrow"
+      :placeholder="definition.placeholder || 'lineType'"
+      @input="$emit('input', $event)"
+    ></dropdown-button>
+  </label>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import IndicatorOptionMixin from '@/mixins/indicatorOptionMixin'
+import DropdownButton from '@/components/framework/DropdownButton.vue'
+
+@Component({
+  name: 'IndicatorOptionLineType',
+  mixins: [IndicatorOptionMixin],
+  components: {
+    DropdownButton
+  }
+})
+export default class IndicatorOptionLineType extends Vue {}
+</script>

--- a/src/components/chart/options/IndicatorOptionList.vue
+++ b/src/components/chart/options/IndicatorOptionList.vue
@@ -1,0 +1,47 @@
+<template>
+  <label class="indicator-option-dropdown form-group">
+    <label>{{ label }}<slot name="description" /></label>
+    <dropdown-button
+      :value="value"
+      :options="options"
+      class="-outline form-control -arrow"
+      :placeholder="definition.placeholder"
+      @input="$emit('input', $event)"
+    ></dropdown-button>
+  </label>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import IndicatorOptionMixin from '@/mixins/indicatorOptionMixin'
+import DropdownButton from '@/components/framework/DropdownButton.vue'
+
+@Component({
+  name: 'IndicatorOptionDropdown',
+  mixins: [IndicatorOptionMixin],
+  components: {
+    DropdownButton
+  }
+})
+export default class IndicatorOptionDropdown extends Vue {
+  private definition
+
+  get options() {
+    if (!this.definition.options) {
+      return []
+    }
+
+    if (Array.isArray(this.definition.options)) {
+      return this.definition.options.reduce((acc, option) => {
+        if (!option) {
+          acc[option] = 'Choose'
+        } else {
+          acc[option] = option
+        }
+        return acc
+      }, {})
+    }
+
+    return this.definition.options
+  }
+}
+</script>

--- a/src/components/chart/options/IndicatorOptionNumber.vue
+++ b/src/components/chart/options/IndicatorOptionNumber.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="indicator-option-number form-group">
+    <label>{{ label }}</label>
+    <editable
+      class="form-control"
+      :value="value"
+      :min="min"
+      :max="max"
+      :step="step"
+      @input="$emit('input', $event)"
+    ></editable>
+  </div>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import IndicatorOptionMixin from '@/mixins/indicatorOptionMixin'
+
+@Component({
+  name: 'IndicatorOptionNumber',
+  mixins: [IndicatorOptionMixin]
+})
+export default class IndicatorOptionNumber extends Vue {
+  private definition
+
+  get min() {
+    return this.definition.min === 'number' ? this.definition.min : null
+  }
+
+  get max() {
+    return this.definition.max === 'number' ? this.definition.max : null
+  }
+
+  get step() {
+    return this.definition.step === 'number' ? this.definition.step : null
+  }
+}
+</script>

--- a/src/components/chart/options/IndicatorOptionRange.vue
+++ b/src/components/chart/options/IndicatorOptionRange.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="indicator-option-range form-group">
+    <label>
+      {{ label }}
+      <editable
+        tag="code"
+        class="indicator-option-range__value -filled"
+        :value="stepRoundedValue"
+        :min="min"
+        :max="max"
+        :step="step"
+        @input="$emit('input', +$event || 0)"
+      ></editable>
+      <slot name="description" />
+    </label>
+    <slider
+      class="mt8"
+      :min="min"
+      :max="max"
+      :step="step"
+      :log="log"
+      :label="true"
+      :value="value"
+      :gradient="gradient"
+      @input="$emit('input', $event)"
+      @reset="$emit('input', definition.value)"
+    />
+  </div>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import IndicatorOptionMixin from '@/mixins/indicatorOptionMixin'
+
+import Slider from '@/components/framework/picker/Slider.vue'
+
+@Component({
+  name: 'IndicatorOptionRange',
+  mixins: [IndicatorOptionMixin],
+  components: {
+    Slider
+  }
+})
+export default class IndicatorOptionRange extends Vue {
+  private value
+  private definition
+
+  get min() {
+    return typeof this.definition.min === 'number' ? this.definition.min : 0
+  }
+
+  get max() {
+    return typeof this.definition.max === 'number' ? this.definition.max : 1
+  }
+
+  get log() {
+    return !!this.definition.log
+  }
+
+  get step() {
+    return typeof this.definition.step === 'number' ? this.definition.step : 0.1
+  }
+
+  get stepRoundedValue() {
+    if (typeof this.value !== 'number') {
+      return this.value
+    }
+
+    return +this.value.toFixed(2)
+  }
+
+  get gradient() {
+    if (!this.definition.gradient || !Array.isArray(this.definition.gradient)) {
+      return null
+    }
+
+    return this.definition.gradient
+  }
+}
+</script>
+<style lang="scss" scoped>
+.indicator-option-range {
+  &__value {
+    font-size: 0.875rem;
+  }
+}
+</style>

--- a/src/components/chart/options/IndicatorOptionText.vue
+++ b/src/components/chart/options/IndicatorOptionText.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="indicator-option-text form-group">
+    <label>{{ label }}<slot name="description" /></label>
+    <editable
+      class="form-control"
+      :value="value"
+      :placeholder="definition.placeholder"
+      @input="$emit('input', $event)"
+    ></editable>
+  </div>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import IndicatorOptionMixin from '@/mixins/indicatorOptionMixin'
+
+@Component({
+  name: 'IndicatorOptionText',
+  mixins: [IndicatorOptionMixin]
+})
+export default class IndicatorOptionText extends Vue {}
+</script>

--- a/src/components/chart/serieBuilder.ts
+++ b/src/components/chart/serieBuilder.ts
@@ -11,7 +11,8 @@ import {
   IndicatorMarkets,
   IndicatorSource,
   MarketsFilters,
-  IndicatorSourceFilters
+  IndicatorSourceFilters,
+  IndicatorOption
 } from './chart'
 import store from '@/store'
 import {
@@ -33,11 +34,25 @@ const SERIE_TYPES = {
   brokenarea: 'range',
   baseline: 'number'
 }
+
+export enum ALLOWED_OPTION_TYPES {
+  text,
+  number,
+  range,
+  list,
+  lineType,
+  lineStyle,
+  color,
+  checkbox,
+  exchange
+}
+
 export default class SerieBuilder {
   private paneId: string
   private markets: string[]
   private indicatorId: string
   private serieIndicatorsMap: { [serieId: string]: IndicatorReference }
+  private allowedOptionsTypes = Object.values(ALLOWED_OPTION_TYPES)
 
   /**
    * build indicator
@@ -82,6 +97,7 @@ export default class SerieBuilder {
       references: result.references,
       markets: result.markets,
       sources: result.sources,
+      options: result.options,
       plots: result.plots
     }
   }
@@ -156,10 +172,14 @@ export default class SerieBuilder {
     const plots: IndicatorPlot[] = []
     const markets: IndicatorMarkets = {}
     const sources: IndicatorSource[] = []
+    const options: { [key: string]: IndicatorOption } = {}
     const references: IndicatorReference[] = []
     const strings = []
 
-    let output = this.parseSources(input, sources)
+    let output = input.replace(/\/\/.*/g, '')
+
+    output = this.parseOptions(output, options)
+    output = this.parseSources(output, sources)
     output = this.normalizeCommonVariables(output)
     output = this.parseStrings(output, strings)
     output = this.parseVariables(output, variables)
@@ -184,13 +204,12 @@ export default class SerieBuilder {
       plots,
       markets,
       references,
+      options,
       sources
     }
   }
 
   parseStrings(input, strings) {
-    input = input.replace(/(\n|^)\s*?\/\/.*/g, '')
-
     const STRING_REGEX = /'([^']*)'|"([^"]*)"/
     let stringMatch = null
     let iterations = 0
@@ -469,7 +488,7 @@ export default class SerieBuilder {
 
     for (let i = startIndex; i < args.length; i++) {
       try {
-        const [, key, value] = args[i].match(/^(\w+)\s*=(.*)/)
+        const [, key, value] = args[i].match(/^(\w+)\s*=([\S\s]*)/)
 
         if (!key || !value.length) {
           continue
@@ -607,6 +626,67 @@ export default class SerieBuilder {
           .join(',')})${output.slice(customArgsEndIndex + 1, output.length)}`
 
         instructions.push(instruction)
+      }
+    } while (functionMatch && ++iterations < 1000)
+
+    return output
+  }
+
+  parseOptions(output, options) {
+    const OPTION_FUNCTION_REGEX = new RegExp(
+      `[\\s\\n]*(\\w[\\d\\w]+)[\\s\\n]*=[\\s\\n]*option\\(`,
+      'g'
+    )
+    let functionMatch = null
+    let iterations = 0
+
+    do {
+      if ((functionMatch = OPTION_FUNCTION_REGEX.exec(output))) {
+        const customArgsStartIndex = functionMatch.index
+        const customArgsEndIndex = findClosingBracketMatchIndex(
+          output,
+          customArgsStartIndex + functionMatch[0].length - 1
+        )
+
+        const optionOptions = this.parseCustomArguments(
+          parseFunctionArguments(
+            output.slice(
+              customArgsStartIndex + functionMatch[0].length,
+              customArgsEndIndex
+            )
+          )
+        )
+
+        output = output.replace(
+          output.slice(customArgsStartIndex, customArgsEndIndex + 1),
+          ''
+        )
+
+        output = output.replace(
+          new RegExp('([^.]|^)\\b(' + functionMatch[1] + ')\\b(?!:|=)', 'ig'),
+          `$1options.${functionMatch[1]}`
+        )
+
+        if (!optionOptions.type) {
+          optionOptions.type = 'number'
+        } else if (optionOptions.type === 'exchange') {
+          optionOptions.rebuild = true
+        }
+
+        if (!optionOptions.default) {
+          optionOptions.default =
+            optionOptions.type === 'text'
+              ? ''
+              : Math.max(optionOptions.min || 0, 0)
+        }
+
+        if (!this.allowedOptionsTypes.includes(optionOptions.type)) {
+          throw new Error(`Unknown option type ${optionOptions.type}`)
+        }
+
+        options[functionMatch[1]] = optionOptions
+
+        OPTION_FUNCTION_REGEX.lastIndex -= functionMatch[0].length
       }
     } while (functionMatch && ++iterations < 1000)
 
@@ -899,7 +979,16 @@ export default class SerieBuilder {
       }
 
       if (!markets.length) {
-        output = output.replace(sourceId, '0')
+        output = output.replace(
+          sourceId,
+          prop
+            ? '0'
+            : `{
+          timestamp: renderer.timestamp,
+          localTimestamp: renderer.localTimestamp,
+          sources: {}
+        }`
+        )
         continue
       }
 

--- a/src/components/framework/Editable.vue
+++ b/src/components/framework/Editable.vue
@@ -1,5 +1,6 @@
 <template>
-  <div
+  <component
+    :is="tag || 'div'"
     :contenteditable="editable !== false"
     :disabled="editable === false"
     @keydown="onKeyDown"
@@ -7,7 +8,7 @@
     @focus="onFocus"
     @blur="onBlur"
     @wheel="onWheel"
-  ></div>
+  ></component>
 </template>
 
 <script lang="ts">
@@ -17,7 +18,7 @@ import { toPlainString } from '@/utils/helpers'
 
 @Component({
   name: 'Editable',
-  props: ['value', 'step', 'min', 'max', 'editable', 'disabled']
+  props: ['value', 'step', 'min', 'max', 'editable', 'disabled', 'tag']
 })
 export default class Editable extends Vue {
   editable: boolean

--- a/src/components/framework/picker/Slider.vue
+++ b/src/components/framework/picker/Slider.vue
@@ -35,7 +35,7 @@ const CURSOR_PADDING = 4
 export default {
   name: 'VerteSlider',
   props: {
-    gradient: Array,
+    gradient: { type: Array, default: null },
     colorCode: { type: Boolean, default: false },
     label: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
@@ -44,7 +44,16 @@ export default {
     step: { type: Number, default: 1 },
     value: { type: Number, default: 0 },
     handlesValue: { type: Array, default: () => [0] },
-    showCompletion: { type: Boolean, default: true },
+    showCompletion: {
+      type: Boolean,
+      default() {
+        if (this.gradient) {
+          return false
+        }
+
+        return true
+      }
+    },
     log: { type: Boolean, default: false }
   },
   data: () => ({
@@ -57,7 +66,16 @@ export default {
     handles: [],
     values: []
   }),
+  computed: {
+    sizeRelatedOptions() {
+      return [this.log, this.min, this.max, this.step]
+    }
+  },
   watch: {
+    sizeRelatedOptions() {
+      this.updateSize()
+      this.updateValue(this.currentValue, true)
+    },
     gradient(val) {
       this.initGradient(val)
       this.reloadHandlesColor()
@@ -249,7 +267,9 @@ export default {
         width = trackRect.width
       }
 
-      this.width = width - CURSOR_PADDING * 2
+      if (width) {
+        this.width = width - CURSOR_PADDING * 2
+      }
 
       this.stepWidth = (this.width / (this.max - this.min)) * this.step
     },
@@ -398,7 +418,11 @@ export default {
     .slider__track {
       background-image: $checkerboard;
       background-size: 6px 6px;
-      background-position: 0 0, 3px -3px, 0 3px, -3px 0px;
+      background-position:
+        0 0,
+        3px -3px,
+        0 3px,
+        -3px 0px;
     }
   }
 

--- a/src/mixins/indicatorOptionMixin.ts
+++ b/src/mixins/indicatorOptionMixin.ts
@@ -1,0 +1,27 @@
+import Vue from 'vue'
+import Component from 'vue-class-component'
+
+@Component({
+  props: {
+    paneId: {
+      type: String,
+      required: true
+    },
+    indicatorId: {
+      type: String,
+      required: true
+    },
+    label: {
+      type: String,
+      required: true
+    },
+    value: {
+      default: null
+    },
+    definition: {
+      type: Object,
+      default: () => ({})
+    }
+  }
+})
+export default class IndicatorOptionMixin extends Vue {}

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -5,6 +5,7 @@ import { ActionTree, GetterTree, Module, MutationTree } from 'vuex'
 import { ModulesState } from '.'
 import TimeframeDialog from '../components/TimeframeDialog.vue'
 import { getApiSupportedMarkets } from '../services/productsService'
+import { IndicatorNavigationState } from './panesSettings/chart'
 
 export interface Notice {
   id?: string
@@ -24,7 +25,7 @@ interface BaseQuoteCurrencies {
 interface NoticeButton {
   text: string
   icon?: string
-  click?: Function
+  click?: () => void
 }
 
 export interface NoticesState {
@@ -61,6 +62,7 @@ export interface AppState {
   quoteCurrency: string
   quoteCurrencySymbol: string
   focusedPaneId: string
+  indicatorDialogNavigation?: IndicatorNavigationState
 }
 
 const state = {
@@ -276,12 +278,15 @@ const mutations = {
 
       if (paneElement) {
         paneElement.classList.remove('pane--selected')
-        paneElement.offsetHeight;
+        paneElement.offsetHeight
         paneElement.classList.add('pane--selected')
       }
     }
 
     state.focusedPaneId = id
+  },
+  SET_INDICATOR_DIALOG_NAVIGATION(state, value) {
+    state.indicatorDialogNavigation = value
   }
 } as MutationTree<AppState>
 

--- a/src/store/panesSettings/chart.ts
+++ b/src/store/panesSettings/chart.ts
@@ -12,6 +12,7 @@ import Vue from 'vue'
 import { MutationTree, ActionTree, GetterTree, Module } from 'vuex'
 import { ModulesState } from '..'
 import merge from 'lodash.merge'
+import { IndicatorOption } from '@/components/chart/chart'
 
 export interface PriceScaleSettings {
   scaleMargins?: PriceScaleMargins
@@ -29,8 +30,8 @@ export interface IndicatorSettings {
   name?: string
   displayName?: string
   description?: string
-  navigationState?: IndicatorNavigationState
   script?: string
+  optionsDefinitions?: { [key: string]: IndicatorOption }
   options?: SeriesOptions<SeriesType>
   createdAt?: number
   updatedAt?: number
@@ -65,7 +66,6 @@ export interface ChartPaneState {
   showTimeScale: boolean
   hiddenMarkets: { [indicatorId: string]: boolean }
   barSpacing: number
-  navigationState: IndicatorNavigationState
 }
 
 const getters = {} as GetterTree<ChartPaneState, ModulesState>
@@ -101,8 +101,7 @@ const state = {
   showRightScale: true,
   showTimeScale: true,
   hiddenMarkets: {},
-  barSpacing: null,
-  navigationState: null
+  barSpacing: null
 } as ChartPaneState
 
 const actions = {
@@ -308,13 +307,6 @@ const actions = {
       }
     }
   },
-  async setIndicatorNavigationState(
-    { commit },
-    navigationState: IndicatorNavigationState
-  ) {
-    state.navigationState = navigationState
-    commit('SET_NAVIGATION_STATE', navigationState)
-  },
   async undoIndicator({ state, commit }, indicatorId) {
     const savedIndicator = await workspacesService.getIndicator(indicatorId)
 
@@ -450,6 +442,9 @@ const mutations = {
       Vue.set(state.indicatorsErrors, id, null)
     }
   },
+  SET_INDICATOR_OPTIONS_DEFINITIONS(state, { id, optionsDefinitions }) {
+    state.indicators[id].optionsDefinitions = optionsDefinitions
+  },
   SET_TIMEFRAME(state, value) {
     state.timeframe = value
   },
@@ -536,9 +531,6 @@ const mutations = {
   },
   SET_BAR_SPACING(state, value) {
     state.barSpacing = value
-  },
-  SET_NAVIGATION_STATE(state, value) {
-    state.navigationState = value
   }
 } as MutationTree<ChartPaneState>
 


### PR DESCRIPTION
Until now the script options were detected from the script itself, if you write options.anything, an option `anything` will magicaly appear in the indicator's settings, and will show differently depending on it's value and name

Defining options with the new `option()` function will allow choose the appropriate input type, set default value, help text and more. 

```typescript
export enum ALLOWED_OPTION_TYPES {
  text,
  number,
  range,
  list,
  lineType,
  lineStyle,
  color,
  checkbox,
  exchange
}
```

## Basic example
<img width="376" alt="image" src="https://github.com/Tucsky/aggr/assets/5738336/87c651ae-75c3-4870-80c0-49a7924e76d7">

```javascript
// default type is number
MyNumber = option(
  default=123, // default value
  label="Number value", // text above input
  placeholder="Type something" // text within empty input 
)
console.log(MyNumber) // 123

// text input
MyText = option(
  type=text,
  label="Text value",
  placeholder="Fill me",
  description="Small description to help understand the option"
)
console.log(MyNumber) // ""
```

> [!NOTE]
> The `xxx = option(...)` code is removed from the script during the build. It's not a variable per definition. You shouldn't try to change it during execution 
> In above example, I can access the option value by using both options.safevalue and safevalue. it all becomes options.safevalue during execution anyway.

```javascript
// number input with `min`, `max` and `step` attribute
threshold = option(type=number, min=0, max=10, step=0.1)
```

## Range input
<img width="489" alt="image" src="https://github.com/Tucsky/aggr/assets/5738336/f836add9-dc04-4259-b0c7-ea7b3cdad3e4">

```javascript
smallrange = option(
  type=range,
  label="Small range",
  min=0,
  max=1
)

bigrange = option(
  type=range,
  label="Big range",
  gradient=["red", "limegreen"], // colorize slider
  min=0,
  max=1000000,
  log=true // slider will ajust displayed value logarithmic scale
)
```

## List input
<img width="387" alt="image" src="https://github.com/Tucsky/aggr/assets/5738336/7569405e-50a8-454d-aa68-a92e6df9109c">

```javascript
// regular list
quote = option(
  type=list,
  options=[null, "USD", "USDT", "TUSD", "USDC", "BUSD"],
  rebuild=true // not specifc to list but will trigger a full indi rebuild when change
)

// custom list item labels
quote = option(
  type=list,
  options={
    "": "Pick something",
    "USD": "United State Dollar",
    "USDT": "Tether",
    "TUSD": "TrueUSD",
    "USDC": "Coinbase USD",
    "BUSD": "Binance USD"
  },
  default=USD
)

// same as list but with predefined exchanges options
exchange = option(type=exchange, rebuild=true)
```

> [!WARNING]
> options must be valid JSON format
> all option values must be wrapped in double-quotes `"`

## Color input
```javascript
// regular color with default value
color = option(type=color,default="red")

// other color format are allowed
color = option(type=color,default="rgba(0, 255, 0, 0.5)")
```

> [!WARNING]
> missing a `,` in the color code, a `"` in the list options, WILL break the whole chart without notice.


## Usage with `source()` function
```javascript
// let user choose spot, perp or both in indicator's settings
type = option(type=list, options=[null, "spot", "perp"])

// get list of markets matching given type 
src = source(type=type)

// aggregate ohlc from markets & print into candlestick serie
candlestick(avg_ohlc(src))
```