### PR TITLE
Convert dist-server script to module

### DIFF
--- a/dist-server/index.mjs
+++ b/dist-server/index.mjs
@@ -1,7 +1,12 @@
-const express = require('express')
-const path = require('node:path')
-const { config } = require('dotenv')
+import express from 'express'
+import path from 'node:path'
+import { config } from 'dotenv'
+
 config()
+
+const __filename = new URL(import.meta.url).pathname
+const __dirname = path.dirname(__filename)
+
 const app = express()
 const PORT = process.env.DIST_SERVER_PORT || 8060
 app.use(express.static(path.join(__dirname, '..', 'dist')))

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "clean": "rm -rf node_modules && npm cache clean -f",
-    "deploy": "node scripts/gh-pages-deploy.mjs"
+    "deploy": "node scripts/gh-pages-deploy.mjs",
+    "serve:dist": "node ./dist-server/index.mjs"
   },
   "dependencies": {
     "@mdi/font": "^5.6.55",


### PR DESCRIPTION
* Add npm script serve:dist to serve dist folder
* User needs to build the app for production it manually first