### PR TITLE
Fixes SearchDialog content removed when trying to clear chart's name in PromptDialog

### DIFF
--- a/src/components/SearchDialog.vue
+++ b/src/components/SearchDialog.vue
@@ -999,6 +999,10 @@ export default {
     },
 
     onKeydown(event) {
+      if (dialogService.isDialogOpened('prompt')) {
+         return false;
+      }
+
       switch (event.key) {
         case 'Enter':
           event.preventDefault()

--- a/src/components/framework/PromptDialog.vue
+++ b/src/components/framework/PromptDialog.vue
@@ -13,6 +13,7 @@
           :placeholder="placeholder"
           v-model="value"
           v-autofocus
+          v-on:keyup.enter="submit"
         />
       </div>
     </form>

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -171,7 +171,7 @@ class DialogService {
       return
     }
 
-    return this.openAsPromise(PromptDialog, options)
+    return this.openAsPromise(PromptDialog, options, 'prompt')
   }
 }
 


### PR DESCRIPTION
This ([4d7356b](https://github.com/Tucsky/aggr/pull/376/commits/4d7356b73cf20a8b283c9307530f6761910eb3bf)) fixes issue #375 by assigning `dialogId` to `PromptDialog` in `DialogService` and then checking if the latter is opened in `SearchDialog` when the `BackSpace` or `Delete` keys are pressed.

We also added a new behavior to the `PromptDialog` ([be782ee](https://github.com/Tucsky/aggr/pull/376/commits/be782eef4a7c338cc60a48cc7a2af348db6dce55)). The input is now submitted when the user presses `Enter`. This makes the validation more intuitive.