### PR TITLE
Small UX improvements of the Chart overlay

### DIFF
--- a/src/assets/sass/pane.scss
+++ b/src/assets/sass/pane.scss
@@ -291,16 +291,8 @@
     line-height: 1;
     color: var(--theme-color-50);
 
-    > button {
-      display: none;
-    }
-
     &:hover {
       color: var(--theme-color-base);
-
-      > button {
-        display: block;
-      }
     }
 
     .pane.-small &,

--- a/src/components/chart/MarketsOverlay.vue
+++ b/src/components/chart/MarketsOverlay.vue
@@ -46,8 +46,7 @@
     >
       <div class="chart-overlay__title">Sources</div>
       <button type="button" class="btn badge -outline" @click="searchMarkets">
-        <span>{{ visibleMarkets }} </span>|
-        <span>Add</span>
+        <span>{{ visibleMarkets }} | Add</span>
       </button>
       <i class="icon-up-thin"></i>
     </div>


### PR DESCRIPTION
This Pull Request addresses a comment found in the Discord channel where the user was proposing to make the Add label of the Chart Overlay always visible instead of revealing on the hover of the drop-down button. 

https://discord.com/channels/1110160121813803058/1115914099071656050/1189675001473937408

The current implementation creates a small jump in the UI that is  discomforting for the user  when it only wants to reveal / then hide the list of indicators or markets which is expected to be done with a double click and not 'click-move to right-click'

The PR also improves the readability of the market overlay label by adding spaces around the separator '|'.

![Add button always visible](https://github.com/Tucsky/aggr/assets/20586054/fb02b025-69b9-449f-8708-475ef80b0a64)

