### PR TITLE
Add trade count column to watchlist pane

### DIFF
--- a/src/components/prices/PricesSettings.vue
+++ b/src/components/prices/PricesSettings.vue
@@ -60,6 +60,32 @@
           <input
             type="checkbox"
             class="form-control"
+            :checked="showCount"
+            @change="$store.commit(paneId + '/TOGGLE_COUNT')"
+          />
+          <div></div>
+          <span>Show count</span>
+        </label>
+      </div>
+
+      <div class="form-group mb8">
+        <label class="checkbox-control -small">
+          <input
+            type="checkbox"
+            class="form-control"
+            :checked="showCountDelta"
+            @change="$store.commit(paneId + '/TOGGLE_COUNT_DELTA')"
+          />
+          <div></div>
+          <span>Show count Δ</span>
+        </label>
+      </div>
+
+      <div class="form-group mb8">
+        <label class="checkbox-control -small">
+          <input
+            type="checkbox"
+            class="form-control"
             :checked="showPrice"
             @change="$store.commit(paneId + '/TOGGLE_PRICE')"
           />
@@ -230,12 +256,20 @@ export default class PricesSettings extends Vue {
     return this.$store.state[this.paneId].showVolume
   }
 
+  get showCount() {
+    return this.$store.state[this.paneId].showCount
+  }
+
   get showPrice() {
     return this.$store.state[this.paneId].showPrice
   }
 
   get showVolumeDelta() {
     return this.$store.state[this.paneId].showVolumeDelta
+  }
+
+  get showCountDelta() {
+    return this.$store.state[this.paneId].showCountDelta
   }
 
   get period() {

--- a/src/components/prices/PricesSortDropdown.vue
+++ b/src/components/prices/PricesSortDropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <dropdown-button
     v-model="sortType"
-    :options="['none', 'price', 'volume', 'delta', 'change']"
+    :options="['none', 'price', 'volume', 'delta', 'change', 'count', 'countDelta']"
     @input="selectSortType($event)"
   ></dropdown-button>
 </template>

--- a/src/store/panesSettings/prices.ts
+++ b/src/store/panesSettings/prices.ts
@@ -7,11 +7,13 @@ export interface PricesPaneState {
   showPairs?: boolean
   showVolume?: boolean
   showVolumeDelta?: boolean
+  showCount?: boolean
+  showCountDelta?: boolean
   period?: number
   showPrice?: boolean
   showChange?: boolean
   sortOrder?: 1 | -1
-  sortType?: 'price' | 'change' | 'volume' | null
+  sortType?: 'price' | 'change' | 'volume' | 'count' | null
   shortSymbols?: boolean
   avgPeriods?: boolean
   volumeThreshold?: number
@@ -26,6 +28,8 @@ const state = {
   showPairs: true,
   showVolume: true,
   showVolumeDelta: true,
+  showCount: true,
+  showCountDelta: true,
   period: 0,
   showChange: true,
   showPrice: true,
@@ -56,6 +60,12 @@ const mutations = {
   },
   TOGGLE_VOLUME_DELTA(state) {
     state.showVolumeDelta = !state.showVolumeDelta
+  },
+  TOGGLE_COUNT(state) {
+    state.showCount = !state.showCount
+  },
+  TOGGLE_COUNT_DELTA(state) {
+    state.showCountDelta = !state.showCountDelta
   },
   SET_PERIOD(state, value) {
     state.period = value

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -119,4 +119,6 @@ export interface Ticker {
   price: number
   volume?: number
   volumeDelta?: number
+  count?: number
+  countDelta?: number
 }

--- a/src/worker/aggregator.ts
+++ b/src/worker/aggregator.ts
@@ -309,6 +309,8 @@ class Aggregator {
     this.tickers[marketKey].volumeDelta +=
       trade.amount * (trade.side === 'buy' ? 1 : -1)
     this.tickers[marketKey].price = trade.price
+    this.tickers[marketKey].count += trade.count
+    this.tickers[marketKey].countDelta += trade.count * (trade.side === 'buy' ? 1 : -1)
 
     if (this.tickers[marketKey].initialPrice === null) {
       this.emitInitialPrice(marketKey, trade.price)
@@ -430,12 +432,16 @@ class Aggregator {
         updatedTickers[marketKey] = {
           price: this.tickers[marketKey].price,
           volume: this.tickers[marketKey].volume,
-          volumeDelta: this.tickers[marketKey].volumeDelta
+          volumeDelta: this.tickers[marketKey].volumeDelta,
+          count: this.tickers[marketKey].count,
+          countDelta: this.tickers[marketKey].countDelta
         }
 
         this.tickers[marketKey].updated = false
         this.tickers[marketKey].volume = 0
         this.tickers[marketKey].volumeDelta = 0
+        this.tickers[marketKey].count = 0
+        this.tickers[marketKey].countDelta = 0
       }
 
       this.ctx.postMessage({ op: 'tickers', data: updatedTickers })
@@ -465,7 +471,9 @@ class Aggregator {
       volume: 0,
       volumeDelta: 0,
       initialPrice: null,
-      price: null
+      price: null,
+      count: 0,
+      countDelta: 0,
     }
 
     this.connectionsCount = Object.keys(this.connections).length


### PR DESCRIPTION
## Overview
We have added a Trade Count column to the Watch List table and implemented functionality similar to the Volume column.

## Modifications
- Added a Trade Count column to the Watch List table
- Implemented features and settings for Trade Count similar to Volume:
  - Toggle visibility
  - Sorting functionality

## Testing
- Confirmed that the visibility toggle for Trade Count works properly
- Ensured that sorting by Trade Count functions correctly

## Items Not Included in This PR
- Count Filter settings
  - Temporarily excluded from implementation due to unstable behavior
  - The basic functionality of the Watch List operates without issues even without this feature

## Future Tasks
- Stabilization and implementation of the Count Filter
